### PR TITLE
fix: navigator pop when using modal-barrier widgets

### DIFF
--- a/example/lib/bottom_sheets.dart
+++ b/example/lib/bottom_sheets.dart
@@ -200,7 +200,7 @@ class _BottomSheetExamplesPageState extends State<BottomSheetExamplesPage> {
                                 onPressed: () {
                                   // How should I unselect all items in the list?
                                   _dropDownCustomBGKey.currentState
-                                      ?.closeDropDownSearch();
+                                      ?.closeDropDownSearch(ctx);
                                 },
                                 child: const Text('Cancel'),
                               ),

--- a/example/lib/dialogs.dart
+++ b/example/lib/dialogs.dart
@@ -200,7 +200,7 @@ class _DialogExamplesPageState extends State<DialogExamplesPage> {
                                       onPressed: () {
                                         // How should I unselect all items in the list?
                                         _dropDownCustomBGKey.currentState
-                                            ?.closeDropDownSearch();
+                                            ?.closeDropDownSearch(ctx);
                                       },
                                       child: const Text('Cancel'),
                                     ),

--- a/example/lib/modals.dart
+++ b/example/lib/modals.dart
@@ -201,7 +201,7 @@ class _ModalsExamplesPageState extends State<ModalsExamplesPage> {
                                 onPressed: () {
                                   // How should I unselect all items in the list?
                                   _dropDownCustomBGKey.currentState
-                                      ?.closeDropDownSearch();
+                                      ?.closeDropDownSearch(ctx);
                                 },
                                 child: const Text('Cancel'),
                               ),

--- a/lib/dropdown_search.dart
+++ b/lib/dropdown_search.dart
@@ -768,11 +768,6 @@ class DropdownSearchState<T> extends State<DropdownSearch<T>> {
     _handleFocus(false);
   }
 
-  @override
-  void dispose() {
-    super.dispose();
-  }
-
   ///Change selected Value; this function is public USED to change the selected
   ///value PROGRAMMATICALLY, Otherwise you can use [_handleOnChangeSelectedItems]
   ///for multiSelection mode you can use [changeSelectedItems]

--- a/lib/dropdown_search.dart
+++ b/lib/dropdown_search.dart
@@ -770,7 +770,6 @@ class DropdownSearchState<T> extends State<DropdownSearch<T>> {
 
   @override
   void dispose() {
-    _popupStateKey.currentState?.closePopup(context);
     super.dispose();
   }
 

--- a/lib/dropdown_search.dart
+++ b/lib/dropdown_search.dart
@@ -770,7 +770,7 @@ class DropdownSearchState<T> extends State<DropdownSearch<T>> {
 
   @override
   void dispose() {
-    _popupStateKey.currentState?.closePopup();
+    _popupStateKey.currentState?.closePopup(context);
     super.dispose();
   }
 
@@ -835,7 +835,7 @@ class DropdownSearchState<T> extends State<DropdownSearch<T>> {
 
   ///validate selected items programmatically passed in param [itemsToValidate]
   void popupValidate(List<T> itemsToValidate) {
-    closeDropDownSearch();
+    closeDropDownSearch(context);
     changeSelectedItems(itemsToValidate);
   }
 
@@ -851,7 +851,8 @@ class DropdownSearchState<T> extends State<DropdownSearch<T>> {
   DropdownSearchPopupState<T>? get getPopupState => _popupStateKey.currentState;
 
   ///close dropdownSearch popup if it's open
-  void closeDropDownSearch() => _popupStateKey.currentState?.closePopup();
+  void closeDropDownSearch(BuildContext context) =>
+      _popupStateKey.currentState?.closePopup(context);
 
   ///returns true if all popup's items are selected; other wise False
   bool get popupIsAllItemSelected =>

--- a/lib/src/widgets/dropdown_search_popup.dart
+++ b/lib/src/widgets/dropdown_search_popup.dart
@@ -278,7 +278,7 @@ class DropdownSearchPopupState<T> extends State<DropdownSearchPopup<T>> {
 
   ///validation of selected items
   void onValidate() {
-    closePopup();
+    closePopup(context);
     if (widget.onChanged != null) widget.onChanged!(_selectedItems);
   }
 
@@ -505,7 +505,8 @@ class DropdownSearchPopupState<T> extends State<DropdownSearchPopup<T>> {
     }
   }
 
-  bool _isDisabled(T item) => widget.popupProps.disabledItemFn?.call(item) == true;
+  bool _isDisabled(T item) =>
+      widget.popupProps.disabledItemFn?.call(item) == true;
 
   /// selected item will be highlighted only when [widget.showSelectedItems] is true,
   /// if our object is String [widget.compareFn] is not required , other wises it's required
@@ -710,7 +711,7 @@ class DropdownSearchPopupState<T> extends State<DropdownSearchPopup<T>> {
         }
       }
     } else {
-      closePopup();
+      closePopup(context);
       if (widget.onChanged != null) {
         widget.onChanged!(List.filled(1, newSelectedItem));
       }
@@ -780,7 +781,7 @@ class DropdownSearchPopupState<T> extends State<DropdownSearchPopup<T>> {
   }
 
   ///close popup
-  void closePopup() => Navigator.pop(context);
+  void closePopup(BuildContext context) => Navigator.pop(context);
 
   void selectAllItems() => selectItems(_currentShowedItems);
 


### PR DESCRIPTION
1. Pass modal widgets context (dialogs/bottom-sheets) to the pop method to not close the page that contains dropdown search instead.
2. Remove pop for `dispose()` because it's not safe to access context in dispose method, and it's not needed

Will fix this https://github.com/salim-lachdhaf/dropdown_search/issues/702