### PR TITLE
Feature/propagate text style via default text style

### DIFF
--- a/lib/dropdown_search.dart
+++ b/lib/dropdown_search.dart
@@ -361,12 +361,17 @@ class DropdownSearchState<T> extends State<DropdownSearch<T>> {
     }
 
     Widget selectedItemWidget() {
+      Widget selectedItem = Text(
+        _itemAsString(getSelectedItem),
+      );
+
       if (widget.dropdownBuilder != null) {
-        return widget.dropdownBuilder!(context, getSelectedItem);
+        selectedItem = widget.dropdownBuilder!(context, getSelectedItem);
       } else if (widget.dropdownBuilderMultiSelection != null) {
-        return widget.dropdownBuilderMultiSelection!(context, getSelectedItems);
+        selectedItem =
+            widget.dropdownBuilderMultiSelection!(context, getSelectedItems);
       } else if (isMultiSelectionMode) {
-        return CustomSingleScrollView(
+        selectedItem = CustomSingleScrollView(
           scrollProps: widget.selectedItemsScrollProps ?? ScrollProps(),
           child: Wrap(
             crossAxisAlignment: WrapCrossAlignment.center,
@@ -376,10 +381,16 @@ class DropdownSearchState<T> extends State<DropdownSearch<T>> {
           ),
         );
       }
-      return Text(
-        _itemAsString(getSelectedItem),
-        style: _getBaseTextStyle(),
+
+      return DefaultTextStyle(
+        style: _getBaseTextStyle() ?? DefaultTextStyle.of(context).style,
         textAlign: widget.decoratorProps.textAlign,
+        softWrap: widget.decoratorProps.softWrap,
+        overflow: widget.decoratorProps.overflow,
+        maxLines: widget.decoratorProps.maxLines,
+        textWidthBasis: widget.decoratorProps.textWidthBasis,
+        textHeightBehavior: widget.decoratorProps.textHeightBehavior,
+        child: selectedItem,
       );
     }
 
@@ -387,10 +398,9 @@ class DropdownSearchState<T> extends State<DropdownSearch<T>> {
   }
 
   TextStyle? _getBaseTextStyle() {
-    return widget.enabled
-        ? widget.decoratorProps.baseStyle
-        : TextStyle(color: Theme.of(context).disabledColor)
-            .merge(widget.decoratorProps.baseStyle);
+    return widget.decoratorProps.baseStyle?.copyWith(
+      color: widget.enabled ? null : Theme.of(context).disabledColor,
+    );
   }
 
   Widget _formField() {

--- a/lib/dropdown_search.dart
+++ b/lib/dropdown_search.dart
@@ -517,15 +517,16 @@ class DropdownSearchState<T> extends State<DropdownSearch<T>> {
         if (widget.suffixProps.clearButtonProps.isVisible &&
             getSelectedItems.isNotEmpty)
           CustomIconButton(
-              props: widget.suffixProps.clearButtonProps,
-              onPressed: clearButtonPressed),
+            props: widget.suffixProps.clearButtonProps,
+            onPressed: widget.enabled ? clearButtonPressed : null,
+          ),
         if (widget.suffixProps.dropdownButtonProps.isVisible)
           CustomIconButton(
             props: widget.suffixProps.dropdownButtonProps,
             icon: isFocused
                 ? widget.suffixProps.dropdownButtonProps.iconOpened
                 : widget.suffixProps.dropdownButtonProps.icon,
-            onPressed: dropdownButtonPressed,
+            onPressed: widget.enabled ? dropdownButtonPressed : null,
           ),
       ],
     );

--- a/lib/src/properties/dropdown_props.dart
+++ b/lib/src/properties/dropdown_props.dart
@@ -1,5 +1,6 @@
 import 'package:dropdown_search/dropdown_search.dart';
 import 'package:flutter/material.dart';
+import 'dart:ui' as ui show TextHeightBehavior;
 
 class DropdownButtonProps extends IconButtonProps {
   final Widget iconOpened;
@@ -351,6 +352,11 @@ class DropDownDecoratorProps {
   final InputDecoration decoration;
   final TextStyle? baseStyle;
   final TextAlign? textAlign;
+  final bool softWrap;
+  final TextOverflow overflow;
+  final int? maxLines;
+  final TextWidthBasis textWidthBasis;
+  final ui.TextHeightBehavior? textHeightBehavior;
   final TextAlignVertical? textAlignVertical;
   final bool expands;
   final bool isHovering;
@@ -362,6 +368,11 @@ class DropDownDecoratorProps {
     ),
     this.baseStyle,
     this.textAlign,
+    this.softWrap = true,
+    this.overflow = TextOverflow.clip,
+    this.maxLines,
+    this.textWidthBasis = TextWidthBasis.parent,
+    this.textHeightBehavior,
     this.textAlignVertical,
     this.expands = false,
     this.isHovering = false,

--- a/lib/src/properties/menu_props.dart
+++ b/lib/src/properties/menu_props.dart
@@ -29,6 +29,11 @@ class MenuProps {
   final String? semanticLabel;
   final Color? surfaceTintColor;
   final EdgeInsets? margin;
+  final SingleChildLayoutDelegate Function(
+    BuildContext context,
+    EdgeInsets padding,
+    RelativeRect position,
+  )? layoutDelegate;
 
   const MenuProps({
     this.align,
@@ -48,5 +53,6 @@ class MenuProps {
     this.semanticLabel,
     this.surfaceTintColor,
     this.margin,
+    this.layoutDelegate,
   });
 }

--- a/lib/src/widgets/popup_menu.dart
+++ b/lib/src/widgets/popup_menu.dart
@@ -149,7 +149,12 @@ class _PopupMenuRoute<T> extends PopupRoute<T> {
     }
 
     return CustomSingleChildLayout(
-      delegate: _PopupMenuRouteLayout(context, mediaQuery.padding, pos),
+      delegate: menuModeProps.layoutDelegate?.call(
+            context,
+            mediaQuery.padding,
+            pos,
+          ) ??
+          _PopupMenuRouteLayout(context, mediaQuery.padding, pos),
       child: capturedThemes.wrap(menu),
     );
   }


### PR DESCRIPTION
Hi @salim-lachdhaf 

This PR i mainly focuses on changing the mechanism of text style propagation and adds more text props

For example - currently there is no way to define `maxLines`(only `textAlign` is available)

In addition to that if you define `dropdownBuilder` - we are loosing all props previously defined in `decoratorPorps`(cause it just renders as is) and we have to reproduce calculation of textStyle based on disabled prop

<img width="1846" alt="image" src="https://github.com/user-attachments/assets/42843bd9-2aa7-471d-a593-9136f40b743c">
