### PR TITLE
Allow menu props to define layout delegate for customisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,39 @@
         },
       )
     ```
+  * add new property `layoutDelegate` to `MenuProps` and `CupertinoMenuProps`, you can extend
+    [`SingleChildLayoutDelegate`](https://api.flutter.dev/flutter/rendering/SingleChildLayoutDelegate-class.html)
+    to create your own positioning strategy
+     
+    example of use
+    ```dart
+      layoutDelegate: (context, padding, position) => _PopupMenuRouteLayout(context, position)
+    
+      class _PopupMenuRouteLayout extends SingleChildLayoutDelegate {
+        final RelativeRect position;
+        final BuildContext context;
+    
+        const _PopupMenuRouteLayout(this.context, this.position);
+    
+      @override
+      BoxConstraints getConstraintsForChild(BoxConstraints constraints) {
+        // pick any properties from the context to calculate proper constraints
+        final mediaQuery = MediaQuery.of(context);
+        final keyBoardHeight = mediaQuery.viewInsets.bottom;
+        final safeArea = mediaQuery.padding;
+    
+        return BoxConstraints(/* calculate new constraints based on your needs */);
+      }
+    
+        @override
+        Offset getPositionForChild(Size size, Size childSize) {
+          // The position where the child should be placed.
+        }
+    
+        @override
+        bool shouldRelayout(covariant SingleChildLayoutDelegate oldDelegate) => false;
+      }
+    ``` 
   * add `SuggestionsProps` to `popupProps`
   * add `builder` property for `SuggestionsProps` to override the hole suggestion widget
   * add properties to `scrollView` and `wrap` widget for selected items in multiSelection mode

--- a/lib/src/popups/menu.dart
+++ b/lib/src/popups/menu.dart
@@ -147,7 +147,11 @@ class _MaterialPopupMenuRoute<T> extends PopupRoute<T> {
       );
 
       return CustomSingleChildLayout(
-        delegate: _PopupMenuRouteLayout(context, position),
+        delegate: menuProps.layoutDelegate?.call(
+          context,
+          position,
+        ) ??
+            _PopupMenuRouteLayout(context, position),
         child: InheritedTheme.capture(
                 from: context, to: Navigator.of(context).context)
             .wrap(menu),
@@ -226,7 +230,11 @@ class _CupertinoPopupMenuRoute<T> extends PopupRoute<T> {
         menuProps.margin,
       );
       return CustomSingleChildLayout(
-        delegate: _PopupMenuRouteLayout(context, position),
+        delegate: menuProps.layoutDelegate?.call(
+          context,
+          position,
+        ) ??
+            _PopupMenuRouteLayout(context, position),
         child: InheritedTheme.capture(
                 from: parentContext, to: Navigator.of(context).context)
             .wrap(menu),

--- a/lib/src/popups/props/menu_props.dart
+++ b/lib/src/popups/props/menu_props.dart
@@ -56,10 +56,17 @@ class MenuProps {
   final Color? surfaceTintColor;
   final EdgeInsets? margin;
   final RouteTransitionsBuilder? transitionBuilder;
+
+  /// This property is exposed in order to give low level access to the
+  /// positioning algorithm of the menu popup
+  /// The delegate can determine the layout constraints for the child and can
+  /// decide where to position the child.
+  /// extend [`SingleChildLayoutDelegate`](https://api.flutter.dev/flutter/rendering/SingleChildLayoutDelegate-class.html)
+  //  to create your own positioning strategy
   final SingleChildLayoutDelegate Function(
-      BuildContext context,
-      RelativeRect position,
-      )? layoutDelegate;
+    BuildContext context,
+    RelativeRect position,
+  )? layoutDelegate;
 
   const MenuProps({
     this.align,
@@ -106,10 +113,17 @@ class CupertinoMenuProps {
   final Color? surfaceTintColor;
   final EdgeInsets? margin;
   final RouteTransitionsBuilder? transitionBuilder;
+
+  /// This property is exposed in order to give low level access to the
+  /// positioning algorithm of the menu popup
+  /// The delegate can determine the layout constraints for the child and can
+  /// decide where to position the child.
+  /// extend [`SingleChildLayoutDelegate`](https://api.flutter.dev/flutter/rendering/SingleChildLayoutDelegate-class.html)
+  //  to create your own positioning strategy
   final SingleChildLayoutDelegate Function(
-      BuildContext context,
-      RelativeRect position,
-      )? layoutDelegate;
+    BuildContext context,
+    RelativeRect position,
+  )? layoutDelegate;
 
   const CupertinoMenuProps({
     this.align,

--- a/lib/src/popups/props/menu_props.dart
+++ b/lib/src/popups/props/menu_props.dart
@@ -56,6 +56,10 @@ class MenuProps {
   final Color? surfaceTintColor;
   final EdgeInsets? margin;
   final RouteTransitionsBuilder? transitionBuilder;
+  final SingleChildLayoutDelegate Function(
+      BuildContext context,
+      RelativeRect position,
+      )? layoutDelegate;
 
   const MenuProps({
     this.align,
@@ -78,6 +82,7 @@ class MenuProps {
     this.surfaceTintColor,
     this.margin,
     this.transitionBuilder,
+    this.layoutDelegate,
   });
 }
 
@@ -101,6 +106,10 @@ class CupertinoMenuProps {
   final Color? surfaceTintColor;
   final EdgeInsets? margin;
   final RouteTransitionsBuilder? transitionBuilder;
+  final SingleChildLayoutDelegate Function(
+      BuildContext context,
+      RelativeRect position,
+      )? layoutDelegate;
 
   const CupertinoMenuProps({
     this.align,
@@ -123,6 +132,7 @@ class CupertinoMenuProps {
     this.surfaceTintColor,
     this.margin = const EdgeInsets.only(top: 8),
     this.transitionBuilder,
+    this.layoutDelegate,
   });
 }
 


### PR DESCRIPTION
Hi @salim-lachdhaf 

Currently there is a straightforward logic of popup positioning
To have more flexibility on that matter it would be nice to add a prop pass through to the MenuProps

This PR is a continuation of https://github.com/salim-lachdhaf/dropdown_search/pull/716