### PR TITLE
allow to pass more props to text widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@
   * add `onDisplayed` callback to `popupProps`
   * add `errorBuilder` for `InfiniteScrollProps`
   * add possibility to reload item using `myGlobalKey.currentState?.reloadItems(String filter)` or `myGlobalKey.currentState?.loadMoreItems(String filter, int skip)`
+  * add `textProps` to have an ability to pass default text props through the context to `selectedItem` 
 
 * #### Breaking changes
   * change `onChanged` to `onSelected`

--- a/lib/src/widgets/props/text_props.dart
+++ b/lib/src/widgets/props/text_props.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+
+class TextProps {
+  final TextStyle? style;
+
+  final TextAlign? textAlign;
+
+  final bool? softWrap;
+
+  final TextOverflow? overflow;
+
+  final int? maxLines;
+
+  final TextWidthBasis? textWidthBasis;
+
+  const TextProps({
+    this.style,
+    this.textAlign,
+    this.softWrap = true,
+    this.overflow = TextOverflow.clip,
+    this.maxLines,
+    this.textWidthBasis = TextWidthBasis.parent,
+  });
+}


### PR DESCRIPTION
Currently we have an ability to pass through `textAlign: widget.decoratorProps.textAlign,` property.

This PR adds an ability to pass all props supported by `Text` widget