### PR TITLE
Changed the focus management

### DIFF
--- a/lib/src/base_dropdown_search.dart
+++ b/lib/src/base_dropdown_search.dart
@@ -302,6 +302,8 @@ class DropdownSearchState<T> extends State<BaseDropdownSearch<T>> {
   CustomOverlayEntry? _customOverlyEntry;
   final autoCompleteFocusNode = FocusNode();
 
+  FocusNode? get dropdownFocusNode => widget.clickProps.focusNode;
+
   @override
   void initState() {
     super.initState();
@@ -905,7 +907,7 @@ class DropdownSearchState<T> extends State<BaseDropdownSearch<T>> {
   ///same thing for clear focus,
   void _handleFocus(bool isFocused) {
     if (isFocused && !_isFocused.value) {
-      FocusScope.of(context).unfocus();
+	  dropdownFocusNode?.requestFocus();
       _isFocused.value = true;
     } else if (!isFocused && _isFocused.value) {
       _isFocused.value = false;


### PR DESCRIPTION
### Behaviour before the patch
As can be seen, when I press on the text field and then move the focus to the dropdown, once it is closed, the focus returns to the text field.

![dropdown_focus_before](https://github.com/user-attachments/assets/9fca5d71-1385-42bf-bdbc-38d1c2a36b52)

### Behaviour after the patch
After the patch, the focus no longer moves to the text field.

![dropdown_focus_after](https://github.com/user-attachments/assets/0f5e5529-dbef-4baa-beb6-e90eb04090fb)


