### PR TITLE
handle hovering state

### DIFF
--- a/lib/src/base_dropdown_search.dart
+++ b/lib/src/base_dropdown_search.dart
@@ -10,6 +10,7 @@ import 'package:dropdown_search/src/widgets/custom_chip.dart';
 import 'package:dropdown_search/src/widgets/custom_icon_button.dart';
 import 'package:dropdown_search/src/widgets/custom_inkwell.dart';
 import 'package:dropdown_search/src/widgets/custom_wrap.dart';
+import 'package:dropdown_search/src/widgets/hover_builder.dart';
 import 'package:dropdown_search/src/widgets/props/text_props.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
@@ -419,35 +420,37 @@ class DropdownSearchState<T> extends State<BaseDropdownSearch<T>> {
             valueListenable: _isFocused,
             builder: (context, isFocused, w) {
               final selectedItems = _buildSelectedItemsWidget();
-              return InputDecorator(
-                baseStyle: _getDecoratorBaseTextStyle(),
-                textAlign: widget.decoratorProps.textAlign,
-                textAlignVertical: widget.decoratorProps.textAlignVertical,
-                isEmpty: getSelectedItem == null,
-                isFocused: isFocused,
-                expands: widget.decoratorProps.expands,
-                isHovering: widget.decoratorProps.isHovering,
-                decoration: _manageDropdownDecoration(state),
-                child: isFocused
-                    ? Row(
-                        children: [
-                          if (selectedItems != null)
-                            Flexible(child: selectedItems),
-                          if (selectedItems != null)
-                            Padding(padding: EdgeInsets.only(left: 4)),
-                          Expanded(
-                            child: TextFormField(
-                              focusNode: autoCompleteFocusNode,
-                              controller: _popupStateKey
-                                  .currentState?.searchBoxController,
-                              decoration:
-                                  InputDecoration(border: InputBorder.none),
+              return HoverBuilder(builder: (context, isHovering) {
+                return InputDecorator(
+                  baseStyle: _getDecoratorBaseTextStyle(),
+                  textAlign: widget.decoratorProps.textAlign,
+                  textAlignVertical: widget.decoratorProps.textAlignVertical,
+                  isEmpty: getSelectedItem == null,
+                  isFocused: isFocused,
+                  expands: widget.decoratorProps.expands,
+                  isHovering: widget.decoratorProps.isHovering ?? isHovering,
+                  decoration: _manageDropdownDecoration(state),
+                  child: isFocused
+                      ? Row(
+                          children: [
+                            if (selectedItems != null)
+                              Flexible(child: selectedItems),
+                            if (selectedItems != null)
+                              Padding(padding: EdgeInsets.only(left: 4)),
+                            Expanded(
+                              child: TextFormField(
+                                focusNode: autoCompleteFocusNode,
+                                controller: _popupStateKey
+                                    .currentState?.searchBoxController,
+                                decoration:
+                                    InputDecoration(border: InputBorder.none),
+                              ),
                             ),
-                          ),
-                        ],
-                      )
-                    : selectedItems,
-              );
+                          ],
+                        )
+                      : selectedItems,
+                );
+              });
             },
           );
         },
@@ -561,17 +564,19 @@ class DropdownSearchState<T> extends State<BaseDropdownSearch<T>> {
         return ValueListenableBuilder<bool>(
             valueListenable: _isFocused,
             builder: (context, isFocused, w) {
-              return InputDecorator(
-                baseStyle: _getDecoratorBaseTextStyle(),
-                textAlign: widget.decoratorProps.textAlign,
-                textAlignVertical: widget.decoratorProps.textAlignVertical,
-                isEmpty: getSelectedItem == null,
-                isFocused: isFocused,
-                expands: widget.decoratorProps.expands,
-                isHovering: widget.decoratorProps.isHovering,
-                decoration: _manageDropdownDecoration(state),
-                child: _buildSelectedItemsWidget(),
-              );
+              return HoverBuilder(builder: (context, isHovering) {
+                return InputDecorator(
+                  baseStyle: _getDecoratorBaseTextStyle(),
+                  textAlign: widget.decoratorProps.textAlign,
+                  textAlignVertical: widget.decoratorProps.textAlignVertical,
+                  isEmpty: getSelectedItem == null,
+                  isFocused: isFocused,
+                  expands: widget.decoratorProps.expands,
+                  isHovering: widget.decoratorProps.isHovering ?? isHovering,
+                  decoration: _manageDropdownDecoration(state),
+                  child: _buildSelectedItemsWidget(),
+                );
+              });
             });
       },
     );
@@ -595,17 +600,19 @@ class DropdownSearchState<T> extends State<BaseDropdownSearch<T>> {
         return ValueListenableBuilder<bool>(
           valueListenable: _isFocused,
           builder: (context, isFocused, w) {
-            return InputDecorator(
-              baseStyle: _getDecoratorBaseTextStyle(),
-              textAlign: widget.decoratorProps.textAlign,
-              textAlignVertical: widget.decoratorProps.textAlignVertical,
-              isEmpty: getSelectedItems.isEmpty,
-              expands: widget.decoratorProps.expands,
-              isHovering: widget.decoratorProps.isHovering,
-              isFocused: isFocused,
-              decoration: _manageDropdownDecoration(state),
-              child: _buildSelectedItemsWidget(),
-            );
+            return HoverBuilder(builder: (context, isHovering) {
+              return InputDecorator(
+                baseStyle: _getDecoratorBaseTextStyle(),
+                textAlign: widget.decoratorProps.textAlign,
+                textAlignVertical: widget.decoratorProps.textAlignVertical,
+                isEmpty: getSelectedItems.isEmpty,
+                expands: widget.decoratorProps.expands,
+                isHovering: widget.decoratorProps.isHovering ?? isHovering,
+                isFocused: isFocused,
+                decoration: _manageDropdownDecoration(state),
+                child: _buildSelectedItemsWidget(),
+              );
+            });
           },
         );
       },

--- a/lib/src/properties/dropdown_props.dart
+++ b/lib/src/properties/dropdown_props.dart
@@ -43,7 +43,7 @@ class DropDownDecoratorProps {
   final TextAlign? textAlign;
   final TextAlignVertical? textAlignVertical;
   final bool expands;
-  final bool isHovering;
+  final bool? isHovering;
 
   const DropDownDecoratorProps({
     this.decoration,
@@ -51,6 +51,6 @@ class DropDownDecoratorProps {
     this.textAlign,
     this.textAlignVertical,
     this.expands = false,
-    this.isHovering = false,
+    this.isHovering,
   });
 }

--- a/lib/src/widgets/hover_builder.dart
+++ b/lib/src/widgets/hover_builder.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+
+class HoverBuilder extends StatefulWidget {
+  const HoverBuilder({
+    required this.builder,
+    super.key,
+  });
+
+  final Widget Function(BuildContext context, bool isHovered) builder;
+
+  @override
+  _HoverBuilderState createState() => _HoverBuilderState();
+}
+
+class _HoverBuilderState extends State<HoverBuilder> {
+  bool _isHovered = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return MouseRegion(
+      onEnter: (event) => _onHoverChanged(enabled: true),
+      onExit: (event) => _onHoverChanged(enabled: false),
+      child: widget.builder(context, _isHovered),
+    );
+  }
+
+  void _onHoverChanged({required bool enabled}) {
+    setState(() {
+      _isHovered = enabled;
+    });
+  }
+}


### PR DESCRIPTION
Hi @salim-lachdhaf 
this PR adds an ability to handle `isHovering` to make input decorator work predictable

add this to see it in aciton 
```dart
                  decoratorProps: DropDownDecoratorProps(
                    decoration: InputDecoration(
                      labelText: 'Examples for: ',
                      hoverColor: Colors.red,
                      filled: true,
                      border: OutlineInputBorder(),
                    ),
                  )
```

https://github.com/user-attachments/assets/be97a7f6-de63-4308-ac6a-ac070a958f27

