### PR TITLE
fix: Refactor DropdownSearchState for UI context retrieval

### DIFF
--- a/lib/src/base_dropdown_search.dart
+++ b/lib/src/base_dropdown_search.dart
@@ -307,12 +307,17 @@ class DropdownSearchState<T> extends State<BaseDropdownSearch<T>> {
   void initState() {
     super.initState();
     _selectedItemsNotifier.value = List.from(widget.selectedItems);
-    _uiToApply = context.getUiToApply(widget.uiMode);
 
     if (widget.popupProps.mode == PopupMode.autocomplete) {
       HardwareKeyboard.instance
           .addHandler(_handleAutoCompleteBackPressKeyPress);
     }
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _uiToApply = context.getUiToApply(widget.uiMode);
   }
 
   bool _handleAutoCompleteBackPressKeyPress(KeyEvent event) {


### PR DESCRIPTION
Resolves #777

Move UI context retrieval to the `didChangeDependencies` method for better lifecycle management in `DropdownSearchState`.