### PR TITLE
Expose an ability to listen to focus changes

### DIFF
--- a/lib/src/adaptive_dropdown_search.dart
+++ b/lib/src/adaptive_dropdown_search.dart
@@ -23,6 +23,7 @@ class AdaptiveDropdownSearch<T> extends BaseDropdownSearch<T> {
     super.compareFn,
     super.onBeforeChange,
     super.onBeforePopupOpening,
+    super.onFocusChange,
     //form properties
     super.onSaved,
     super.validator,
@@ -55,6 +56,7 @@ class AdaptiveDropdownSearch<T> extends BaseDropdownSearch<T> {
     super.onSelected,
     super.onBeforeChange,
     super.onBeforePopupOpening,
+    super.onFocusChange,
     super.dropdownBuilder,
     //form properties
     super.onSaved,

--- a/lib/src/base_dropdown_search.dart
+++ b/lib/src/base_dropdown_search.dart
@@ -162,6 +162,9 @@ abstract class BaseDropdownSearch<T> extends StatefulWidget {
 
   final Object? groupId;
 
+  /// Called when the focus state changes.
+  final void Function(bool)? onFocusChange;
+
   BaseDropdownSearch({
     super.key,
     this.groupId,
@@ -187,6 +190,7 @@ abstract class BaseDropdownSearch<T> extends StatefulWidget {
     this.chipProps,
     DropDownDecoratorProps? decoratorProps,
     this.textProps = const TextProps(),
+    this.onFocusChange,
   })  : assert(
           T == String || T == int || T == double || compareFn != null,
           '`compareFn` is required',
@@ -242,6 +246,7 @@ abstract class BaseDropdownSearch<T> extends StatefulWidget {
     ValueChanged<List<T>>? onSelected,
     BeforeChangeMultiSelection<T>? onBeforeChange,
     BeforePopupOpeningMultiSelection<T>? onBeforePopupOpening,
+    this.onFocusChange,
     DropdownSearchBuilderMultiSelection<T>? dropdownBuilder,
     //form properties
     FormFieldSetter<List<T>>? onSaved,
@@ -313,6 +318,10 @@ class DropdownSearchState<T> extends State<BaseDropdownSearch<T>> {
       HardwareKeyboard.instance
           .addHandler(_handleAutoCompleteBackPressKeyPress);
     }
+
+    _isFocused.addListener(() {
+      widget.onFocusChange?.call(_isFocused.value);
+    });
   }
 
   bool _handleAutoCompleteBackPressKeyPress(KeyEvent event) {
@@ -384,6 +393,7 @@ class DropdownSearchState<T> extends State<BaseDropdownSearch<T>> {
   void dispose() {
     closeDropDownSearch();
     autoCompleteFocusNode.dispose();
+    _isFocused.dispose();
     HardwareKeyboard.instance
         .removeHandler(_handleAutoCompleteBackPressKeyPress);
     super.dispose();

--- a/lib/src/cupertino_dropdown_search.dart
+++ b/lib/src/cupertino_dropdown_search.dart
@@ -21,6 +21,7 @@ class CupertinoDropdownSearch<T> extends BaseDropdownSearch<T> {
     super.compareFn,
     super.onBeforeChange,
     super.onBeforePopupOpening,
+    super.onFocusChange,
     //form properties
     super.onSaved,
     super.validator,
@@ -50,6 +51,7 @@ class CupertinoDropdownSearch<T> extends BaseDropdownSearch<T> {
     super.onSelected,
     super.onBeforeChange,
     super.onBeforePopupOpening,
+    super.onFocusChange,
     super.dropdownBuilder,
     //form properties
     super.onSaved,

--- a/lib/src/dropdown_search.dart
+++ b/lib/src/dropdown_search.dart
@@ -20,6 +20,7 @@ class DropdownSearch<T> extends BaseDropdownSearch<T> {
     super.compareFn,
     super.onBeforeChange,
     super.onBeforePopupOpening,
+    super.onFocusChange,
     //form properties
     super.onSaved,
     super.validator,
@@ -49,6 +50,7 @@ class DropdownSearch<T> extends BaseDropdownSearch<T> {
     super.onSelected,
     super.onBeforeChange,
     super.onBeforePopupOpening,
+    super.onFocusChange,
     super.dropdownBuilder,
     //form properties
     super.onSaved,


### PR DESCRIPTION
Hi @salim-lachdhaf 

This PR aims to solve a tricky handling of widget focus and expose it to external consumers.

Currently this package has it's own `isFocused` management mostly due to the fact that regular focus not will not help
The focus node unfocuses itself when popup opens or user taps the search box.

This package implements a clever workaround and I would like to expose it to external consumers to be able to hook into the events of focus.